### PR TITLE
Support for multiple channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,33 @@ Plugin for [IRC-Bot](https://github.com/greboid/irc-bot)
 
 Receives notifications from a URL instance and outputs them to a channel.
 
- - go build github.com/greboid/irc-webhook/v4/cmd/webhook
- - docker run ghcr.io/greboid/irc-webhook
- 
+- go build github.com/greboid/irc-webhook/v4/cmd/webhook
+- docker run ghcr.io/greboid/irc-webhook
+
 ### Configuration
 
 The following configuration settings are supported:
 
-| Flag         | Env var     | Default     | Description                            |
-|--------------|-------------|-------------|----------------------------------------|
-| `-rpc-host`  | `RPC_HOST`  | `localhost` | Hostname of the IRC-bot instance       |
-| `-rpc-port`  | `RPC_PORT`  | `8001`      | Port to connect to IRC-bot on          |
-| `-rpc-token` | `RPC_TOKEN` | -           | Authentication token for IRC-bot       |
-| `-channel`   | `CHANNEL`   | -           | Channel to send messages to by default |
-| `-debug`     | `DEBUG`     | `false`     | Whether to enable debug logging        |
-| `-db-path`   | `DB_PATH`   | `/data/db`  | Path to store token database           |
-| `-admin-key` | `ADMIN_KEY` | -           | Default key for incoming requests      |
+| Flag                | Env var            | Default     | Description                                   |
+|---------------------|--------------------|-------------|-----------------------------------------------|
+| `-rpc-host`         | `RPC_HOST`         | `localhost` | Hostname of the IRC-bot instance              |
+| `-rpc-port`         | `RPC_PORT`         | `8001`      | Port to connect to IRC-bot on                 |
+| `-rpc-token`        | `RPC_TOKEN`        | -           | Authentication token for IRC-bot              |
+| `-channel`          | `CHANNEL`          | -           | Channel to send messages to by default        |
+| `-allowed-channels` | `ALLOWED_CHANNELS` | -           | List of channels that messages may be sent to |
+| `-debug`            | `DEBUG`            | `false`     | Whether to enable debug logging               |
+| `-db-path`          | `DB_PATH`          | `/data/db`  | Path to store token database                  |
+| `-admin-key`        | `ADMIN_KEY`        | -           | Default key for incoming requests             |
+
+#### Multi-channel support
+
+By default, all messages will be sent to the channel specified in the `channel`
+flag/env var.
+
+To enable multi-channel support, set `allowed-channels` to a comma-separated
+list of additional channels to allow (e.g. `#channel1,#channel2,#channel3`).
+You can also set `allowed-channels` to `*` to allow clients to send messages
+anywhere.
 
 ### API
 
@@ -30,14 +41,18 @@ the admin key specified in the config, or a key created using the keys API.
 
 #### /webhook/sendmessage
 
-Sends a message to IRC.
+Sends a message to IRC. If allowed channels is specified in the config, you
+can specify the channel as well.
 
 ```http
 POST /webhooks/sendmessage HTTP/1.1
 X-Api-Key: my-key
 Content-Type: application/json
 
-{"message": "Hello world!"}
+{
+  "message": "Hello world!",
+  "channel": "#some-non-default-channel"
+}
 ```
 
 ```http


### PR DESCRIPTION
By default, maintains the same behaviour as before: all messages
will go to the default channel.

Setting allowed-channels to `*` will allow clients to specify
any channel they like (including usernames to PM people) in
a `channel` property in payloads.

Setting allowed-channels to a comma-separated list will allow
messages to be sent only to those channels.